### PR TITLE
Investigate onServiceOnlineReg name server calls

### DIFF
--- a/broadcastSvcAddrRemote_scenarios_analysis.md
+++ b/broadcastSvcAddrRemote_scenarios_analysis.md
@@ -1,0 +1,209 @@
+# broadcastSvcAddrRemote 接口调用场景分析
+
+## 概述
+`broadcastSvcAddrRemote` 是 CNameServer 中用于向远程（跨主机）客户端广播服务地址信息的核心接口。该接口主要处理跨网络/跨主机的服务发现和地址同步。
+
+## 接口定义
+
+```cpp
+// 三个重载版本
+void CNameServer::broadcastSvcAddrRemote(
+    const CFdbToken::tTokenList &tokens,  // 安全令牌列表
+    FdbMsgAddressList &addr_list,         // 地址列表
+    CFdbMessage *msg                      // 消息对象（用于获取session）
+)
+
+void CNameServer::broadcastSvcAddrRemote(
+    const CFdbToken::tTokenList &tokens,
+    FdbMsgAddressList &addr_list,
+    CFdbSession *session                  // 直接指定session
+)
+
+void CNameServer::broadcastSvcAddrRemote(
+    const CFdbToken::tTokenList &tokens,
+    FdbMsgAddressList &addr_list         // 广播给所有订阅者
+)
+```
+
+## 主要调用场景
+
+### 1. 服务注册时的远程广播 (onRegisterServiceReq)
+
+当服务成功注册到 Name Server 后，需要通知远程主机的客户端：
+
+```cpp
+void CNameServer::onRegisterServiceReq(CBaseJob::Ptr &msg_ref)
+{
+    // ... 服务注册逻辑 ...
+    
+    // 准备不同类型的地址列表
+    prepareAddressesToNotify(best_local_url, *reg_entry, 
+                            local_addr_list,      // 本地地址
+                            remote_tcp_addr_list, // 远程TCP地址
+                            all_addr_list);       // 所有地址
+    
+    // 向远程客户端广播TCP地址
+    if (!remote_tcp_addr_list.address_list().empty())
+    {
+        // 发送所有令牌到本地name server，它会根据安全级别发送合适的令牌给本地客户端
+        broadcastSvcAddrRemote(reg_entry->mTokens, remote_tcp_addr_list);
+    }
+}
+```
+
+**触发条件**：
+- 新服务启动并注册
+- 服务地址发生变更
+- 服务重新绑定地址
+
+### 2. 服务注销时的远程通知 (removeService)
+
+当服务注销时，需要通知所有远程订阅者服务已下线：
+
+```cpp
+bool CNameServer::removeService(const char *svc_name, FdbInstanceId_t instance_id)
+{
+    // ... 准备广播数据 ...
+    
+    // 通知本地客户端
+    broadcastSvcAddrLocal(reg_entry->mTokens, broadcast_addr_list);
+    
+    // 设置为非本地标志
+    broadcast_addr_list.set_is_local(false);
+    
+    // 通知远程客户端（跨主机）
+    // 发送所有令牌到本地name server，它会根据安全级别发送合适的令牌
+    broadcastSvcAddrRemote(reg_entry->mTokens, broadcast_addr_list);
+    
+    // ... 清理资源 ...
+}
+```
+
+**触发条件**：
+- 服务主动注销（调用 unregister）
+- 服务异常断开连接
+- 服务进程退出
+
+### 3. 响应远程订阅请求 (onServiceOnlineReg)
+
+当远程客户端订阅服务上线通知时，需要立即返回当前服务状态：
+
+```cpp
+void CNameServer::broadServiceAddress(const CSvcRegistryEntry &reg_entry, 
+                                     CFdbMessage *msg,
+                                     SubscribeType subscribe_type)
+{
+    // 如果是跨主机普通订阅
+    if (subscribe_type == INTER_NORMAL)
+    {
+        // 向远程订阅者广播服务地址
+        broadcastSvcAddrRemote(reg_entry.mTokens, addr_list, msg);
+    }
+    // ... 处理其他订阅类型 ...
+}
+```
+
+**订阅类型说明**：
+- `INTER_NORMAL`: 跨主机普通服务订阅（远程客户端连接远程服务）
+- `INTER_MONITOR`: 跨主机服务监控订阅（远程监控工具）
+
+### 4. 服务地址分配时的通知 (onAllocServiceAddressReq)
+
+虽然地址分配请求本身不直接调用 `broadcastSvcAddrRemote`，但分配成功后的注册流程会触发远程广播。
+
+## 安全令牌处理
+
+`broadcastSvcAddrRemote` 的一个重要功能是处理安全令牌：
+
+```cpp
+void CNameServer::populateTokensRemote(const CFdbToken::tTokenList &tokens,
+                                      FdbMsgAddressList &addr_list,
+                                      CFdbSession *session)
+{
+    // 获取远程主机的安全级别
+    int32_t security_level = getSecurityLevel(session, svc_name);
+    
+    // 只发送匹配安全级别的令牌
+    for (int32_t i = 0; i <= security_level; ++i) 
+    {
+        addr_list.token_list().add_tokens(tokens[i].c_str());
+    }
+}
+```
+
+**安全机制**：
+- 根据远程主机的安全级别过滤令牌
+- 只发送该主机有权访问的令牌
+- 保证跨网络访问的安全性
+
+## 广播机制
+
+### 1. 点对点广播
+```cpp
+// 通过消息的session广播给特定订阅者
+broadcastSvcAddrRemote(tokens, addr_list, msg);
+```
+
+### 2. 指定Session广播
+```cpp
+// 直接指定session进行广播
+broadcastSvcAddrRemote(tokens, addr_list, session);
+```
+
+### 3. 全量广播
+```cpp
+// 广播给所有INTER_NORMAL订阅者
+broadcastSvcAddrRemote(tokens, addr_list);
+```
+
+## 典型调用流程
+
+```
+服务注册/注销/状态变化
+    ↓
+准备地址列表（区分本地和远程）
+    ↓
+检查是否有远程TCP地址
+    ↓
+调用 broadcastSvcAddrRemote()
+    ↓
+populateTokensRemote() 处理安全令牌
+    ↓
+通过 mInterNormalPublisher 广播
+    ↓
+远程订阅者接收到服务地址更新
+```
+
+## 与其他广播接口的区别
+
+| 接口 | 目标 | 使用场景 | 发布者对象 |
+|-----|------|---------|-----------|
+| `broadcastSvcAddrLocal` | 本地客户端 | 同主机内服务发现 | mIntraNormalPublisher |
+| `broadcastSvcAddrRemote` | 远程客户端 | 跨主机服务发现 | mInterNormalPublisher |
+| 直接broadcast | 监控客户端 | 服务状态监控 | mIntra/InterMonitorPublisher |
+
+## 重要特性
+
+1. **地址过滤**：只广播TCP地址给远程客户端（IPC地址不适用于跨主机）
+2. **安全控制**：通过令牌机制控制访问权限
+3. **导出级别**：根据服务的导出级别决定是否向远程广播
+4. **实时性**：服务状态变化立即通知所有订阅者
+5. **可靠性**：支持重连和状态同步
+
+## 使用注意事项
+
+1. Name Server 自身的地址不会通过 `INTER_NORMAL` 广播给远程
+2. 监控类订阅不包含安全令牌
+3. 远程广播只包含可导出的地址（exportable_level > NODE_INTERNAL）
+4. 需要确保网络连接的稳定性
+
+## 总结
+
+`broadcastSvcAddrRemote` 是 FDBus 分布式服务架构中的关键接口，主要在以下场景被调用：
+
+1. **服务生命周期管理**：注册、注销、地址变更
+2. **跨主机服务发现**：响应远程订阅请求
+3. **安全访问控制**：基于令牌的权限管理
+4. **实时状态同步**：确保远程客户端获得最新服务信息
+
+该接口是实现跨网络、跨主机服务通信的核心组件，保证了分布式系统中服务的可发现性和可访问性。

--- a/cross_host_address_transmission_path.md
+++ b/cross_host_address_transmission_path.md
@@ -1,0 +1,186 @@
+# 跨主机服务地址传输路径分析
+
+## 答案
+**是的，您的理解完全正确！**
+
+本地服务的地址和端口号传输路径是：
+1. **本地Name Server** → TCP → **对端Name Server**  
+2. **对端Name Server** → IPC → **对端Client**
+
+## 详细传输路径
+
+### 完整的传输链路
+
+```
+主机A (服务端)                        主机B (客户端)
+--------------                        --------------
+                                     Client
+                                        ↑
+                                      IPC通信
+                                        ↑
+Local Service                    Remote Name Server
+     ↓                                  ↑
+   IPC通信                            TCP通信
+     ↓                                  ↑
+Local Name Server ←───────TCP通信──────→ CInterNameProxy
+```
+
+## 具体实现分析
+
+### 1. Name Server之间的TCP连接
+
+```cpp
+// CInterNameProxy 连接到远程 Name Server
+CInterNameProxy::CInterNameProxy(container, host_ip, ns_url, host_name)
+{
+    // ns_url 是远程Name Server的TCP地址
+    // 例如: "tcp://192.168.1.100:60002"
+    mNsUrl = ns_url;
+}
+
+// 建立TCP连接
+proxy->connectToNameServer();  // 通过TCP连接到远程Name Server
+```
+
+### 2. 本地Name Server与Client的IPC连接
+
+```cpp
+// CIntraNameProxy 连接本地 Name Server
+CIntraNameProxy::CIntraNameProxy()
+{
+#if defined(__WIN32__) || defined(CONFIG_FORCE_LOCALHOST)
+    // Windows使用TCP本地回环
+    mNsUrl = CNsConfig::getNameServerTCPUrl();  // "tcp://127.0.0.1:60002"
+#else
+    // Linux/Unix使用IPC（Unix Domain Socket）
+    mNsUrl = CNsConfig::getNameServerIPCUrl();  // "ipc:///tmp/fdb-ns"
+#endif
+}
+```
+
+### 3. 地址传输流程
+
+#### 阶段1：服务地址通过TCP发送到远程Name Server
+
+```cpp
+// 本地 Name Server
+void CNameServer::broadcastSvcAddrRemote(tokens, addr_list, msg)
+{
+    // 通过TCP连接发送
+    mInterNormalPublisher.broadcast(session->sid(), 
+                                   addr_list.instance_id(), 
+                                   builder,
+                                   addr_list.service_name());
+}
+// 数据格式：
+// addr_list = {
+//     service_name: "ivi_server"
+//     address: "tcp://192.168.1.100:3456"
+//     tokens: [...]
+// }
+```
+
+#### 阶段2：远程Name Server接收并转发给本地Client
+
+```cpp
+// 远程 CInterNameProxy 接收（通过TCP）
+void CInterNameProxy::onServiceBroadcast(msg, INTER_NORMAL)
+{
+    // 解析从TCP收到的地址信息
+    FdbMsgAddressList msg_addr_list;
+    msg->deserialize(msg_addr_list);
+    
+    // 转换订阅类型：INTER_NORMAL → INTRA_NORMAL
+    auto forward_type = INTRA_NORMAL;
+    
+    // 通过IPC转发给本地客户端
+    name_server->broadcastSvcAddrLocal(tokens, msg_addr_list);
+}
+```
+
+#### 阶段3：客户端通过IPC接收地址
+
+```cpp
+// 客户端的 CIntraNameProxy（通过IPC连接）
+void CIntraNameProxy::onServiceBroadcast(msg_ref)
+{
+    // 从本地Name Server通过IPC收到地址
+    FdbMsgAddressList msg_addr_list;
+    msg->deserialize(msg_addr_list);
+    
+    // 获得远程服务地址：tcp://192.168.1.100:3456
+    doConnectToServer(context, ep_id, msg_addr_list);
+}
+```
+
+## 通信协议对比
+
+| 阶段 | 连接类型 | 协议 | 路径示例 |
+|------|---------|------|----------|
+| Name Server之间 | 跨主机 | TCP | `tcp://192.168.1.100:60002` |
+| Name Server与本地Client | 本机内 | IPC/UDS | `ipc:///tmp/fdb-ns` |
+| Client最终连接Service | 跨主机 | TCP | `tcp://192.168.1.100:3456` |
+
+## 为什么这样设计？
+
+### 1. 安全性
+- Name Server之间通过TCP通信，可以加密和认证
+- 本地通信使用IPC，更安全且性能更好
+
+### 2. 性能优化
+- 本机内使用IPC（Unix Domain Socket）：
+  - 无需网络协议栈
+  - 零拷贝传输
+  - 延迟更低
+
+### 3. 架构清晰
+- Name Server作为中介，隔离客户端和服务端
+- 客户端不需要知道远程Name Server地址
+- 服务发现完全透明
+
+## 数据流示意图
+
+```
+时序图：
+T1: ClientB → IPC → NameServerB: 订阅 ivi_server
+T2: NameServerB(CInterNameProxy) → TCP → NameServerA: INTER_NORMAL订阅
+T3: NameServerA: 查找 ivi_server，返回 tcp://192.168.1.100:3456
+T4: NameServerA → TCP → NameServerB: 发送地址信息
+T5: NameServerB → IPC → ClientB: 转发地址信息
+T6: ClientB → TCP → ServiceA: 建立连接到 tcp://192.168.1.100:3456
+```
+
+## 关键代码路径
+
+```cpp
+// 1. 远程Name Server订阅
+CInterNameProxy::mInterNormalSubscriber.subscribe()
+    ↓ TCP
+// 2. 本地Name Server响应
+CNameServer::onServiceOnlineReg()
+→ broadcastSvcAddrRemote()
+    ↓ TCP
+// 3. 远程Name Server接收
+CInterNameProxy::onServiceBroadcast()
+→ broadcastSvcAddrLocal()
+    ↓ IPC
+// 4. 客户端接收
+CIntraNameProxy::onServiceBroadcast()
+→ doConnectToServer()
+    ↓ TCP
+// 5. 连接到服务
+CBaseClient::doConnect("tcp://192.168.1.100:3456")
+```
+
+## 总结
+
+FDBus采用了混合通信模式：
+- **跨主机通信**：使用TCP（Name Server之间，Client到远程Service）
+- **本机内通信**：使用IPC/UDS（Client与本地Name Server之间）
+
+这种设计兼顾了：
+- 跨网络的可达性（TCP）
+- 本地通信的高性能（IPC）
+- 系统的安全性和可维护性
+
+您的理解非常准确，这正是FDBus服务发现机制的精髓所在。

--- a/cross_host_tcp_connection_flow.md
+++ b/cross_host_tcp_connection_flow.md
@@ -1,0 +1,205 @@
+# 跨主机服务TCP连接完整流程分析
+
+## 概述
+在FDBus分布式系统中，跨主机服务连接经过以下阶段：
+1. 远程客户端订阅服务
+2. 本地Name Server返回服务地址（IP+端口）
+3. 远程Name Server转发地址给客户端
+4. 客户端建立TCP连接
+
+## 完整流程
+
+### 第一阶段：远程订阅请求
+
+```
+远程主机                              本地主机
+--------                             --------
+Client                               ivi_server (已注册)
+  ↓ connect("svc://ivi_server")          ↑
+  ↓                                      ↑
+Remote Name Server                   Local Name Server
+  ↓                                      ↑
+CInterNameProxy ──INTER_NORMAL订阅──→    ↑
+                                         ↑
+                              onServiceOnlineReg()
+```
+
+### 第二阶段：地址信息返回
+
+```cpp
+// 1. 本地Name Server处理订阅
+onServiceOnlineReg(svc_name="ivi_server", subscribe_type=INTER_NORMAL)
+    ↓
+// 2. 查找本地服务
+findService("ivi_server") // 找到已注册的服务
+    ↓
+// 3. 广播服务地址
+broadServiceAddress(reg_entry, msg, INTER_NORMAL)
+    ↓
+// 4. 准备TCP地址列表（跨主机只能用TCP，不能用IPC）
+populateAddrList(reg_entry.mAddrTbl, addr_list, FDB_SOCKET_TCP)
+    ↓
+// 5. 发送给远程订阅者
+broadcastSvcAddrRemote(tokens, addr_list, msg)
+```
+
+### 第三阶段：远程接收和转发
+
+```cpp
+// 远程CInterNameProxy接收到地址
+CInterNameProxy::onServiceBroadcast(msg, INTER_NORMAL)
+    ↓
+// 解析地址列表
+FdbMsgAddressList msg_addr_list {
+    service_name: "ivi_server"
+    instance_id: 0
+    address_list: [
+        {
+            tcp_ipc_url: "tcp://192.168.1.100:3456"
+            address_type: FDB_SOCKET_TCP
+            tcp_ipc_address: "192.168.1.100"
+            tcp_port: 3456
+            is_secure: false
+        }
+    ]
+    host_name: "local_host"
+    token_list: [security_tokens]
+}
+    ↓
+// 转发给本地客户端（INTER_NORMAL → INTRA_NORMAL）
+name_server->broadcastSvcAddrLocal(tokens, addr_list)
+```
+
+### 第四阶段：客户端建立TCP连接
+
+```cpp
+// 客户端收到服务地址广播
+CIntraNameProxy::onServiceBroadcast()
+    ↓
+// 连接到服务器
+doConnectToServer(context, ep_id, msg_addr_list)
+    ↓
+// 对每个匹配的客户端实例
+for (each client matching service_name) {
+    doConnectToAddress(client, msg_addr_list)
+        ↓
+    // 实际建立TCP连接
+    client->doConnect("tcp://192.168.1.100:3456", "local_host")
+        ↓
+    // 创建客户端socket
+    CClientSocket* sk = new CClientSocket(...)
+        ↓
+    // 建立TCP连接
+    session = sk->connect()  // 底层TCP连接建立
+}
+```
+
+### 第五阶段：TCP连接建立
+
+```cpp
+// CBaseClient::doConnect实现
+CClientSocket* CBaseClient::doConnect(const char *url, ...) 
+{
+    // 1. 解析URL
+    parseUrl("tcp://192.168.1.100:3456", addr)
+    
+    // 2. 创建socket实现
+    auto client_imp = CBaseSocketFactory::createClientSocket(addr)
+    // 这里会创建CTcpClientSocket
+    
+    // 3. 创建客户端socket容器
+    auto sk = new CClientSocket(this, skid, client_imp, ...)
+    
+    // 4. 发起TCP连接
+    auto session = sk->connect()
+    // 底层调用 socket() + connect() 系统调用
+    
+    // 5. 连接成功，创建会话
+    if (session) {
+        addConnectedSession(sk, session)
+        notifyConnectReady(CONNECTED)
+    }
+    
+    return sk;
+}
+```
+
+## 数据流转细节
+
+### 1. 地址信息格式
+```protobuf
+FdbMsgAddressList {
+    string service_name        // 服务名称
+    uint32 instance_id         // 实例ID
+    repeated AddressItem {
+        string tcp_ipc_url     // 完整URL："tcp://IP:PORT"
+        string tcp_ipc_address // IP地址："192.168.1.100"
+        int32 tcp_port         // 端口号：3456
+        bool is_secure         // 是否安全连接
+        int32 address_type     // FDB_SOCKET_TCP
+    }
+    string host_name           // 主机名
+    repeated string tokens     // 安全令牌
+}
+```
+
+### 2. 地址过滤规则
+- **跨主机只发送TCP地址**：IPC（Unix Domain Socket）地址被过滤
+- **安全级别控制**：根据exportable_level决定是否导出
+- **令牌过滤**：根据远程主机的安全级别发送相应令牌
+
+### 3. 连接优先级
+```cpp
+// validateUrl()中的优先级顺序
+1. IPC (Unix Domain Socket) - 跨主机不可用
+2. localhost (127.0.0.1)     - 跨主机不可用
+3. 具体IP地址                 - 跨主机使用
+4. 0.0.0.0 (all interfaces)  - 替换为实际IP
+```
+
+## 关键函数调用时序
+
+```
+时间 →
+T1: 远程客户端 connect("svc://ivi_server")
+T2: 远程NS → 本地NS: INTER_NORMAL订阅请求
+T3: 本地NS: onServiceOnlineReg()
+T4: 本地NS: broadcastSvcAddrRemote() 返回 "tcp://192.168.1.100:3456"
+T5: 远程NS: onServiceBroadcast() 接收地址
+T6: 远程NS → 远程客户端: 转发地址信息
+T7: 远程客户端: doConnect("tcp://192.168.1.100:3456")
+T8: TCP三次握手建立连接
+T9: 连接成功，开始通信
+```
+
+## 重要特性
+
+### 1. 自动地址发现
+- 客户端只需指定服务名，不需要知道具体地址
+- Name Server自动返回可用地址
+
+### 2. 跨网络支持
+- 自动过滤不可跨网络的地址（IPC）
+- 只返回TCP地址给远程客户端
+
+### 3. 安全控制
+- 通过令牌机制控制访问权限
+- 支持安全和非安全连接
+
+### 4. 负载均衡潜力
+- 可以返回多个地址供选择
+- 客户端可以选择最优地址连接
+
+## 总结
+
+**是的，在这个流程之后，对端（远程客户端）就能够收到本机的IP+端口，并开始进行TCP连接。**
+
+具体步骤：
+1. 远程收到地址信息（如 "tcp://192.168.1.100:3456"）
+2. 解析出IP地址和端口号
+3. 创建TCP socket
+4. 调用connect()系统调用建立连接
+5. 完成TCP三次握手
+6. 建立会话，开始FDBus协议通信
+
+这个机制使得FDBus能够透明地处理跨主机服务发现和连接，应用程序只需要知道服务名称，底层的地址解析和TCP连接建立都由框架自动完成。

--- a/log_analysis_inter_normal_subscription.md
+++ b/log_analysis_inter_normal_subscription.md
@@ -1,0 +1,95 @@
+# 日志分析：跨主机客户端订阅请求
+
+## 日志内容
+```
+行 15767: onServiceOnlineReg:1422
+行 15768: broadServiceAddress:1355  
+行 15769: broadcastSvcAddrRemote:586
+行 15770: CNameServer: Registry of ivi_server is received from remote.
+```
+
+## 分析结论
+
+**是的，这是收到了跨主机（远程）客户端的订阅请求消息。**
+
+## 详细解释
+
+### 1. 调用链分析
+
+从日志可以看到完整的调用链：
+```
+onServiceOnlineReg (行1422)
+  ↓
+broadServiceAddress (行1355)  
+  ↓
+broadcastSvcAddrRemote (行586)
+  ↓
+打印日志 "Registry of ivi_server is received from remote"
+```
+
+### 2. 关键代码分析
+
+在 `onServiceOnlineReg` 函数中（行1411-1414）：
+```cpp
+if ((subscribe_type == INTER_NORMAL) || (subscribe_type == INTER_MONITOR))
+{
+    LOG_I("CNameServer: Registry of %s is received from remote.\n",
+            svc_name[0] == '\0' ? "all services" : svc_name);
+}
+```
+
+这个日志只有在订阅类型为 `INTER_NORMAL` 或 `INTER_MONITOR` 时才会打印。
+
+### 3. 订阅类型判断
+
+在 `broadServiceAddress` 函数中（行1379-1381）：
+```cpp
+else if (subscribe_type == INTER_NORMAL)
+{
+    broadcastSvcAddrRemote(reg_entry.mTokens, addr_list, msg);
+}
+```
+
+调用 `broadcastSvcAddrRemote` 说明订阅类型是 `INTER_NORMAL`。
+
+### 4. 远程订阅来源
+
+`INTER_NORMAL` 类型的订阅来自 `CInterNameProxy`，它代表远程主机的 Name Server 代理：
+
+- **CInterNameProxy** 是远程 Name Server 的客户端代理
+- 它通过 `mInterNormalSubscriber` 订阅服务状态
+- 当远程主机的客户端需要连接本地服务时，远程 Name Server 会通过 CInterNameProxy 订阅本地服务
+
+### 5. 具体场景
+
+根据日志，实际发生的场景是：
+
+1. **远程主机的客户端** 想要连接到本地主机的 `ivi_server` 服务
+2. **远程 Name Server** 通过 CInterNameProxy 向本地 Name Server 订阅 `ivi_server` 的状态
+3. **本地 Name Server** 收到订阅请求，触发 `onServiceOnlineReg`
+4. 查找本地是否有 `ivi_server` 服务
+5. 如果有，通过 `broadcastSvcAddrRemote` 将服务地址发送给远程订阅者
+6. 打印日志表示收到了远程的服务订阅请求
+
+## 网络拓扑示意
+
+```
+远程主机                           本地主机
+--------                          --------
+Client                            ivi_server
+  ↓                                  ↓
+Remote Name Server  <---订阅--->  Local Name Server
+       ↓                              ↑
+  CInterNameProxy ----INTER_NORMAL----↑
+                     (订阅请求)
+```
+
+## 关键点总结
+
+1. **订阅类型**：`INTER_NORMAL` - 跨主机普通服务订阅
+2. **订阅目标**：`ivi_server` 服务
+3. **订阅方向**：从远程主机到本地主机
+4. **处理方式**：广播服务的 TCP 地址给远程订阅者
+5. **安全控制**：通过 token 机制控制访问权限
+
+这个日志序列清楚地表明：本地 Name Server 收到了来自远程主机的客户端（通过远程 Name Server 代理）对 `ivi_server` 服务的订阅请求。

--- a/onServiceOnlineReg_scenarios_analysis.md
+++ b/onServiceOnlineReg_scenarios_analysis.md
@@ -1,0 +1,154 @@
+# onServiceOnlineReg 接口调用场景分析
+
+## 概述
+`onServiceOnlineReg` 是 FDBus Name Server 中的一个重要接口，用于处理服务上线订阅注册。当有客户端订阅服务上线通知时，该接口会被调用。
+
+## 接口定义
+```cpp
+void CNameServer::onServiceOnlineReg(
+    const char *svc_name,           // 服务名称
+    FdbInstanceId_t instance_id,    // 实例ID
+    CBaseJob::Ptr &msg_ref,         // 消息引用
+    SubscribeType subscribe_type    // 订阅类型
+)
+```
+
+## 订阅类型 (SubscribeType)
+```cpp
+enum SubscribeType {
+    INTRA_NORMAL = FDB_CUSTOM_OBJECT_BEGIN,  // 本地普通服务订阅
+    INTRA_MONITOR,                            // 本地服务监控订阅
+    INTER_NORMAL,                             // 跨主机普通服务订阅
+    INTER_MONITOR,                            // 跨主机服务监控订阅
+    MORE_ADDRESS                              // 更多地址订阅
+};
+```
+
+## 调用场景
+
+### 1. 客户端连接服务时
+当客户端（CBaseClient）需要连接到服务器时，会触发以下流程：
+
+```
+客户端调用 connect() 
+    ↓
+CIntraNameProxy::listenOnService()
+    ↓
+订阅服务上线通知 (INTRA_NORMAL)
+    ↓
+ConnectAddrPublisher::onSubscribe()
+    ↓
+CNameServer::onServiceOnlineReg()
+```
+
+**具体场景**：
+- 客户端启动并尝试连接到指定的服务
+- 客户端需要获取服务的地址信息（TCP/IPC/UDP端口）
+- 客户端监听服务的上线状态变化
+
+### 2. 服务注册时的广播
+当新服务注册到 Name Server 时：
+
+```
+服务端调用 bind()
+    ↓
+CIntraNameProxy::registerService()
+    ↓
+Name Server 注册服务
+    ↓
+广播给所有订阅者
+    ↓
+触发已有订阅者的 onServiceOnlineReg()
+```
+
+**具体场景**：
+- 新服务启动并注册到 Name Server
+- 服务重启后重新注册
+- 服务地址发生变化时的更新通知
+
+### 3. 跨主机服务发现
+在分布式环境中，当远程主机的服务信息需要同步时：
+
+```
+远程 Name Server 连接
+    ↓
+CInterNameProxy 订阅服务 (INTER_NORMAL)
+    ↓
+ConnectAddrPublisher::onSubscribe()
+    ↓
+CNameServer::onServiceOnlineReg()
+```
+
+**具体场景**：
+- 多主机环境中的服务发现
+- 远程服务的地址信息同步
+- 跨网络的服务连接
+
+### 4. 服务监控场景
+当需要监控服务状态时：
+
+```
+监控客户端订阅 (INTRA_MONITOR/INTER_MONITOR)
+    ↓
+ConnectAddrPublisher::onSubscribe()
+    ↓
+CNameServer::onServiceOnlineReg()
+```
+
+**具体场景**：
+- 系统监控工具监控服务状态
+- 服务健康检查
+- 服务拓扑图的实时更新
+
+## 接口处理逻辑
+
+当 `onServiceOnlineReg` 被调用时，它会执行以下操作：
+
+1. **查找匹配的服务**
+   - 根据 `svc_name` 和 `instance_id` 查找已注册的服务
+   - 支持通配符匹配（空字符串表示所有服务）
+
+2. **广播服务地址**
+   - 向订阅者发送服务的地址信息
+   - 包括 TCP、IPC、UDP 等不同类型的地址
+
+3. **转发到其他 Name Server**
+   - 对于跨主机场景，将服务信息转发给其他主机的 Name Server
+   - 确保服务信息在整个分布式系统中同步
+
+4. **权限和安全控制**
+   - 根据订阅类型和服务的导出级别进行访问控制
+   - 区分本地服务和远程服务的访问权限
+
+## 使用示例
+
+### 客户端订阅服务上线通知
+```cpp
+// 客户端代码
+CBaseClient client("client_name");
+client.connect("svc://service_name");  // 自动触发服务订阅
+```
+
+### 服务端注册服务
+```cpp
+// 服务端代码
+CBaseServer server("server_name");
+server.bind("svc://service_name");  // 注册后会通知所有订阅者
+```
+
+## 重要说明
+
+1. **订阅机制**：采用发布-订阅模式，支持一对多的通知
+2. **实时性**：服务状态变化会立即通知所有订阅者
+3. **可靠性**：支持服务重连和地址更新
+4. **扩展性**：支持跨主机和分布式部署
+
+## 总结
+
+`onServiceOnlineReg` 是 FDBus 服务发现机制的核心接口，主要在以下场景被调用：
+- 客户端连接服务时的地址发现
+- 服务注册/注销时的状态广播
+- 跨主机服务信息同步
+- 服务监控和健康检查
+
+该接口确保了 FDBus 系统中服务的动态发现和连接管理，是实现分布式服务架构的关键组件。

--- a/remote_nameserver_receive_flow_and_logs.md
+++ b/remote_nameserver_receive_flow_and_logs.md
@@ -1,0 +1,274 @@
+# 对端Name Server接收地址的调用流程和日志分析
+
+## 完整调用流程
+
+当对端Name Server收到本机发送的服务地址和端口后，会经历以下调用流程：
+
+### 1. TCP接收阶段
+
+```cpp
+CInterNameProxy::ConnectAddrSubscriber::onBroadcast()  // TCP消息到达
+    ↓
+CInterNameProxy::onServiceBroadcast()                  // 处理服务广播
+    ↓
+CNameServer::broadcastSvcAddrLocal()                   // 转发给本地客户端
+    ↓
+CIntraNameProxy::onServiceBroadcast()                  // 客户端接收
+    ↓
+CIntraNameProxy::connectToServer()                     // 发起连接
+    ↓
+CIntraNameProxy::doConnectToServer()                   // 实际连接处理
+    ↓
+CIntraNameProxy::doConnectToAddress()                  // 建立TCP连接
+    ↓
+CBaseClient::doConnect()                               // 底层连接
+```
+
+## 详细接口调用和日志
+
+### 阶段1：CInterNameProxy接收TCP消息
+
+```cpp
+// 1.1 订阅消息到达
+void CInterNameProxy::ConnectAddrSubscriber::onBroadcast(CBaseJob::Ptr &msg_ref)
+{
+    // 解析消息
+    FdbMsgAddressList msg_addr_list;
+    CFdbParcelableParser parser(msg_addr_list);
+    if (!msg->deserialize(parser))
+    {
+        return;  // 解析失败，无日志
+    }
+    
+    // 调用服务广播处理
+    mNsProxy->onServiceBroadcast(msg, mType);
+}
+
+// 此阶段无日志输出
+```
+
+### 阶段2：处理服务广播
+
+```cpp
+// 1.2 处理服务地址广播
+void CInterNameProxy::onServiceBroadcast(CFdbMessage *msg, SubscribeType subscribe_type)
+{
+    // subscribe_type = INTER_NORMAL
+    auto forward_type = INTRA_NORMAL;  // 转换为本地订阅类型
+    
+    // 解析地址列表
+    FdbMsgAddressList msg_addr_list;
+    // msg_addr_list = {
+    //     service_name: "ivi_server"
+    //     address: "tcp://192.168.1.100:3456"
+    //     instance_id: 0
+    //     host_name: "remote_host"
+    // }
+    
+    // 检查是否有本地客户端订阅了该服务
+    tSubscribedSessionSets sessions;
+    mContainer->nameServer()->getSvcSubscribeTable(msg->code(), svc_name, sessions, forward_type);
+    
+    if (sessions.empty())
+    {
+        // 如果没有本地客户端订阅，取消远程订阅
+        name_server->recallServiceListener(msg->code(), svc_name, subscribe_type);
+        return;
+    }
+    
+    // 验证和调整URL（处理0.0.0.0等特殊地址）
+    validateUrl(msg_addr_list, session);
+    
+    // 转发给本地客户端
+    name_server->broadcastSvcAddrLocal(tokens, msg_addr_list);
+}
+
+// 此阶段无日志输出（除非出错）
+```
+
+### 阶段3：本地Name Server转发
+
+```cpp
+void CNameServer::broadcastSvcAddrLocal(const CFdbToken::tTokenList &tokens,
+                                        FdbMsgAddressList &addr_list)
+{
+    // 通过IPC发送给本地客户端
+    // 使用mIntraNormalPublisher广播
+    
+    // 此阶段无日志
+}
+```
+
+### 阶段4：客户端接收并连接
+
+```cpp
+// 4.1 客户端的CIntraNameProxy接收广播
+void CIntraNameProxy::onServiceBroadcast(CBaseJob::Ptr &msg_ref)
+{
+    connectToServer(msg, ctx_id, ep_id);
+}
+
+// 4.2 连接到服务器
+void CIntraNameProxy::doConnectToServer(CFdbBaseContext *context, 
+                                        FdbEndpointId_t ep_id,
+                                        FdbMsgAddressList &msg_addr_list, 
+                                        bool is_init_response)
+{
+    auto svc_name = msg_addr_list.service_name().c_str();  // "ivi_server"
+    auto instance_id = msg_addr_list.instance_id();        // 0
+    const std::string &host_name = msg_addr_list.host_name(); // "remote_host"
+    bool is_offline = msg_addr_list.address_list().empty();
+    
+    // 遍历所有匹配的客户端
+    for (each matching client)
+    {
+        if (is_offline)
+        {
+            // 服务下线
+            client->doDisconnect();
+            
+            // 🔴 日志1：服务下线
+            LOG_E("CIntraNameProxy Client %s:%d is disconnected by %s!\n", 
+                  svc_name, instance_id, host_name.c_str());
+            // 输出: "CIntraNameProxy Client ivi_server:0 is disconnected by remote_host!"
+        }
+        else
+        {
+            // 服务上线，建立连接
+            doConnectToAddress(client, msg_addr_list, udp_failure, udp_success, tcp_failure);
+        }
+    }
+}
+
+// 4.3 建立实际连接
+void CIntraNameProxy::doConnectToAddress(CBaseClient *client,
+                                         FdbMsgAddressList &msg_addr_list,
+                                         bool &udp_failure,
+                                         bool &udp_success,
+                                         bool &tcp_failure)
+{
+    const char *svc_name = msg_addr_list.service_name().c_str();
+    const char *host_name = msg_addr_list.host_name().c_str();
+    auto instance_id = msg_addr_list.instance_id();
+    
+    // 遍历地址列表（通常只有一个TCP地址）
+    for (auto it = addr_list.vpool().begin(); it != addr_list.vpool().end(); ++it)
+    {
+        // it->tcp_ipc_url() = "tcp://192.168.1.100:3456"
+        
+        auto session_container = client->doConnect(it->tcp_ipc_url().c_str(),
+                                                   host_name, udp_port);
+        
+        if (session_container)
+        {
+            if (client->UDPEnabled() && (udp_port > FDB_INET_PORT_NOBIND))
+            {
+                if (!获取UDP端口成功)
+                {
+                    // 🔴 日志2：UDP连接失败
+                    LOG_I("CIntraNameProxy: Server: %s:%d, address %s UDP %d is connected but UDP fail.\n",
+                          svc_name, instance_id, it->tcp_ipc_url().c_str(), udp_port);
+                    // 输出: "CIntraNameProxy: Server: ivi_server:0, address tcp://192.168.1.100:3456 UDP 4567 is connected but UDP fail."
+                }
+                else
+                {
+                    // 🟢 日志3：连接成功（含UDP）
+                    LOG_I("CIntraNameProxy: Server: %s:%d, address %s UDP %d is connected.\n",
+                          svc_name, instance_id, it->tcp_ipc_url().c_str(), socket_info.mAddress->mPort);
+                    // 输出: "CIntraNameProxy: Server: ivi_server:0, address tcp://192.168.1.100:3456 UDP 4567 is connected."
+                }
+            }
+        }
+        else
+        {
+            // 🔴 日志4：TCP连接失败
+            LOG_I("CIntraNameProxy: Server: %s:%d, address %s fail to connect TCP.\n",
+                  svc_name, instance_id, it->tcp_ipc_url().c_str());
+            // 输出: "CIntraNameProxy: Server: ivi_server:0, address tcp://192.168.1.100:3456 fail to connect TCP."
+        }
+    }
+}
+```
+
+### 阶段5：底层TCP连接
+
+```cpp
+CClientSocket *CBaseClient::doConnect(const char *url, const char *host_name, int32_t udp_port)
+{
+    // url = "tcp://192.168.1.100:3456"
+    
+    CFdbSocketAddr addr;
+    if (!CBaseSocketFactory::parseUrl(url, addr))
+    {
+        // 🔴 日志5：URL解析失败
+        LOG_E("CBaseClient: unable to parse url: %s!\n", url);
+        return 0;
+    }
+    
+    if (addr.mSecure && !TCPSecureEnabled())
+    {
+        // 🔴 日志6：安全连接失败
+        LOG_I("CBaseClient: unable to connect to %s since security is not enabled!\n", url);
+        return 0;
+    }
+    
+    // 创建TCP socket并连接
+    auto client_imp = CBaseSocketFactory::createClientSocket(addr);
+    auto sk = new CClientSocket(this, skid, client_imp, host_name, udp_port, addr.mSecure);
+    auto session = sk->connect();
+    
+    // 连接成功后，通知上层
+    notifyConnectReady(CONNECTED);
+    
+    return sk;
+}
+```
+
+## 预期日志输出
+
+### 成功场景（TCP连接成功）
+
+```bash
+# 对端接收到地址后的日志序列：
+[CIntraNameProxy] Server: ivi_server:0, address tcp://192.168.1.100:3456 UDP 4567 is connected.
+```
+
+### 失败场景1（TCP连接失败）
+
+```bash
+[CIntraNameProxy] Server: ivi_server:0, address tcp://192.168.1.100:3456 fail to connect TCP.
+```
+
+### 失败场景2（服务下线）
+
+```bash
+[CIntraNameProxy] Client ivi_server:0 is disconnected by remote_host!
+```
+
+### 失败场景3（UDP失败但TCP成功）
+
+```bash
+[CIntraNameProxy] Server: ivi_server:0, address tcp://192.168.1.100:3456 UDP 4567 is connected but UDP fail.
+```
+
+## 关键点总结
+
+### 调用链
+1. **CInterNameProxy** - 通过TCP接收远程Name Server的消息
+2. **onServiceBroadcast** - 解析地址并验证
+3. **broadcastSvcAddrLocal** - 通过IPC转发给本地客户端
+4. **CIntraNameProxy** - 本地客户端接收地址
+5. **doConnect** - 建立TCP连接到远程服务
+
+### 日志特征
+- **连接成功**：打印 "Server: xxx is connected"
+- **连接失败**：打印 "fail to connect TCP"
+- **服务下线**：打印 "Client xxx is disconnected"
+- **大部分中间步骤无日志**，只在最终连接阶段才有日志输出
+
+### 数据转换
+- 订阅类型：`INTER_NORMAL` → `INTRA_NORMAL`
+- 通信协议：TCP（Name Server间） → IPC（本地） → TCP（连接服务）
+- 地址格式：保持 `tcp://IP:PORT` 格式不变
+
+这个流程确保了跨主机服务发现的透明性和可靠性。


### PR DESCRIPTION
Add `onServiceOnlineReg_scenarios_analysis.md` to document the call scenarios for the `onServiceOnlineReg` name server interface.

---
<a href="https://cursor.com/background-agent?bcId=bc-faf1c10a-d7fc-4a4b-928a-156f71d442da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-faf1c10a-d7fc-4a4b-928a-156f71d442da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

